### PR TITLE
Complete functionality of strip event webhooks for subscription

### DIFF
--- a/.env_local
+++ b/.env_local
@@ -1,0 +1,2 @@
+STRIPE_SECRET_KEY=Your_stripe_secret_key_here
+STRIPE_WEBHOOK_SECRET=Your_stripe_webhook_secrey_here

--- a/Gemfile
+++ b/Gemfile
@@ -51,10 +51,14 @@ gem "bootsnap", require: false
 gem 'stripe'
 gem 'dotenv-rails'
 gem 'rubocop', '~> 1.65'
+# State Machine Gem
+gem 'aasm'
+
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
+  gem 'byebug', '~> 11.1.1', platforms: %i[mri mingw x64_mingw]
   gem 'rspec-rails'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    aasm (5.5.0)
+      concurrent-ruby (~> 1.0)
     actioncable (7.0.8.4)
       actionpack (= 7.0.8.4)
       activesupport (= 7.0.8.4)
@@ -76,6 +78,7 @@ GEM
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.3.0)
+    byebug (11.1.3)
     capybara (3.39.2)
       addressable
       matrix
@@ -289,8 +292,10 @@ PLATFORMS
   arm64-darwin-22
 
 DEPENDENCIES
+  aasm
   annotate
   bootsnap
+  byebug (~> 11.1.1)
   capybara
   database_cleaner
   debug

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class WebhooksController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def stripe
+    event = construct_event(request)
+    return if event.nil?
+
+    StripeEventHandlers::Dispatcher.call(event)
+    render json: { message: 'Success' }, status: :ok
+  end
+
+  private
+
+  def construct_event(request)
+    payload = request.body.read
+    sig_header = request.env['HTTP_STRIPE_SIGNATURE']
+
+    Stripe::Webhook.construct_event(payload, sig_header, ENV['STRIPE_WEBHOOK_SECRET'])
+  rescue JSON::ParserError
+    render_error('Invalid payload')
+  rescue Stripe::SignatureVerificationError
+    render_error('Invalid signature')
+  end
+
+  def render_error(message)
+    render json: { error: message }, status: :bad_request
+  end
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -12,4 +12,28 @@
 #  stripe_subscription_id :string           not null
 #
 class Subscription < ApplicationRecord
+  include AASM
+
+  validates :stripe_subscription_id, presence: true, uniqueness: true
+  validates :status, :stripe_customer_id, presence: true
+
+  enum status: { unpaid: 'unpaid', paid: 'paid', canceled: 'canceled' }
+
+  aasm column: 'status' do
+    state :unpaid, initial: true
+    state :paid
+    state :canceled
+
+    event :pay do
+      transitions from: %i[unpaid paid], to: :paid
+    end
+
+    event :cancel do
+      transitions from: :paid, to: :canceled
+    end
+  end
+
+  def status=(_value)
+    raise 'Direct assignment of status is not allowed. Use state machine events instead.'
+  end
 end

--- a/app/services/stripe_event_handlers/base.rb
+++ b/app/services/stripe_event_handlers/base.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module StripeEventHandlers
+  class Base
+    def initialize(event)
+      @event = event
+    end
+
+    def handle
+      raise NotImplementedError, 'Each handler must implement the handle method'
+    end
+  end
+end

--- a/app/services/stripe_event_handlers/dispatcher.rb
+++ b/app/services/stripe_event_handlers/dispatcher.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module StripeEventHandlers
+  class Dispatcher
+    EVENT_HANDLERS = {
+      'customer.subscription.created' => StripeEventHandlers::SubscriptionCreated,
+      'invoice.payment_succeeded' => StripeEventHandlers::PaymentSucceeded,
+      'customer.subscription.deleted' => StripeEventHandlers::SubscriptionDeleted
+    }.freeze
+
+    def self.call(event)
+      handler = EVENT_HANDLERS[event.type]
+
+      unless handler
+        Rails.logger.info "Unhandled event type: #{event.type}"
+        return nil
+      end
+
+      handler.new(event).handle
+    end
+  end
+end

--- a/app/services/stripe_event_handlers/payment_succeeded.rb
+++ b/app/services/stripe_event_handlers/payment_succeeded.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module StripeEventHandlers
+  class PaymentSucceeded < StripeEventHandlers::Base
+    def handle
+      invoice = @event.data.object
+      SubscriptionService::Update.new(invoice.subscription, 'invoice.payment_succeeded').call
+    end
+  end
+end

--- a/app/services/stripe_event_handlers/subscription_created.rb
+++ b/app/services/stripe_event_handlers/subscription_created.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module StripeEventHandlers
+  class SubscriptionCreated < StripeEventHandlers::Base
+    def handle
+      subscription = @event.data.object
+      SubscriptionService::Create.new(subscription.id, subscription.customer).call
+    end
+  end
+end

--- a/app/services/stripe_event_handlers/subscription_deleted.rb
+++ b/app/services/stripe_event_handlers/subscription_deleted.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module StripeEventHandlers
+  class SubscriptionDeleted < StripeEventHandlers::Base
+    def handle
+      subscription = @event.data.object
+      SubscriptionService::Update.new(subscription.id, 'customer.subscription.deleted').call
+    end
+  end
+end

--- a/app/services/subscription_service/create.rb
+++ b/app/services/subscription_service/create.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module SubscriptionService
+  class Create
+    def initialize(stripe_subscription_id, stripe_customer_id)
+      @stripe_subscription_id = stripe_subscription_id
+      @stripe_customer_id = stripe_customer_id
+    end
+
+    def call
+      Subscription.create!(stripe_subscription_id: @stripe_subscription_id, stripe_customer_id: @stripe_customer_id)
+    end
+  end
+end

--- a/app/services/subscription_service/update.rb
+++ b/app/services/subscription_service/update.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module SubscriptionService
+  class Update
+    def initialize(stripe_subscription_id, event)
+      @stripe_subscription_id = stripe_subscription_id
+      @event = event
+    end
+
+    def call
+      subscription = Subscription.find_by(stripe_subscription_id: @stripe_subscription_id)
+      return unless subscription
+
+      case @event
+      when 'invoice.payment_succeeded'
+        pay_subscription(subscription)
+      when 'customer.subscription.deleted'
+        cancel_subscription(subscription)
+      end
+    end
+
+    private
+
+    def pay_subscription(subscription)
+      subscription.pay! if subscription.may_pay?
+    end
+
+    def cancel_subscription(subscription)
+      subscription.cancel! if subscription.may_cancel?
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,5 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "articles#index"
+  post 'webhooks/stripe', to: 'webhooks#stripe'
 end

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :subscription do
+    stripe_subscription_id { "sub_#{SecureRandom.hex(8)}" }
+    stripe_customer_id { "cus_#{SecureRandom.hex(8)}" }
+  end
+end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -14,5 +14,34 @@
 require 'rails_helper'
 
 RSpec.describe Subscription, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:subscription) { create(:subscription) }
+
+  it 'should have an initial state of unpaid' do
+    expect(subscription.status).to eq('unpaid')
+  end
+
+  it 'should transition from unpaid to paid' do
+    expect(subscription.may_pay?).to be true
+    subscription.pay!
+    expect(subscription.status).to eq('paid')
+  end
+
+  it 'should transition from paid to canceled' do
+    subscription.pay!
+    expect(subscription.may_cancel?).to be true
+    subscription.cancel!
+    expect(subscription.status).to eq('canceled')
+  end
+
+  it 'should not allow transition from unpaid to canceled' do
+    expect(subscription.may_cancel?).to be false
+    expect { subscription.cancel! }.to raise_error(AASM::InvalidTransition)
+  end
+
+  it 'should raise an error on direct status assignment' do
+    expect do
+      subscription.update(status: 'canceled')
+    end.to raise_error(RuntimeError,
+                       'Direct assignment of status is not allowed. Use state machine events instead.')
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -35,6 +35,7 @@ RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = Rails.root.join('spec/fixtures')
 
+  config.include FactoryBot::Syntax::Methods
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.

--- a/spec/requests/webhooks_spec.rb
+++ b/spec/requests/webhooks_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Webhooks', type: :request do
+  let(:stripe_subscription_id) { "sub_#{SecureRandom.hex(8)}" }
+  let(:stripe_customer_id) { "cus_#{SecureRandom.hex(8)}" }
+  let(:body) { '{}' }
+  let(:headers) { { 'HTTP_STRIPE_SIGNATURE' => 'valid_signature' } }
+
+  before do
+    allow(Stripe::Webhook).to receive(:construct_event).and_return(stripe_event)
+  end
+
+  describe 'POST /webhooks/stripe' do
+    context 'when event is customer.subscription.created' do
+      let(:stripe_event) do
+        Stripe::Event.construct_from(
+          id: 'evt_123',
+          type: 'customer.subscription.created',
+          data: { object: { id: stripe_subscription_id, customer: stripe_customer_id } }
+        )
+      end
+
+      it 'creates a new subscription' do
+        expect do
+          post '/webhooks/stripe', params: body, headers: headers, as: :json
+        end.to change(Subscription, :count).by(1)
+        subscription = Subscription.last
+        expect(subscription.stripe_subscription_id).to eq(stripe_subscription_id)
+        expect(subscription.status).to eq('unpaid')
+      end
+    end
+
+    context 'when event is invoice.payment_succeeded' do
+      let!(:subscription) { create(:subscription, stripe_subscription_id: stripe_subscription_id) }
+      let(:stripe_event) do
+        Stripe::Event.construct_from(
+          id: 'evt_123',
+          type: 'invoice.payment_succeeded',
+          data: { object: { subscription: stripe_subscription_id } }
+        )
+      end
+
+      it 'updates subscription status to paid' do
+        post '/webhooks/stripe', params: body, headers: headers, as: :json
+        expect(subscription.reload.status).to eq('paid')
+      end
+    end
+
+    context 'when event is customer.subscription.deleted' do
+      let!(:subscription) { create(:subscription, stripe_subscription_id: stripe_subscription_id) }
+      let(:stripe_event) do
+        Stripe::Event.construct_from(
+          id: 'evt_123',
+          type: 'customer.subscription.deleted',
+          data: { object: { id: stripe_subscription_id } }
+        )
+      end
+
+      context 'when subscription status is paid' do
+        before { subscription.pay! }
+
+        it 'updates subscription status to canceled' do
+          post '/webhooks/stripe', params: body, headers: headers, as: :json
+          expect(subscription.reload.status).to eq('canceled')
+        end
+      end
+
+      it 'does not update subscription status if it is unpaid' do
+        post '/webhooks/stripe', params: body, headers: headers, as: :json
+        expect(subscription.reload.status).to eq('unpaid')
+      end
+    end
+  end
+end

--- a/spec/services/stripe_event_handlers/base_spec.rb
+++ b/spec/services/stripe_event_handlers/base_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe StripeEventHandlers::Base do
+  let(:event) { double('event') }
+
+  describe '#initialize' do
+    it 'initializes with an event' do
+      handler = described_class.new(event)
+      expect(handler.instance_variable_get(:@event)).to eq(event)
+    end
+  end
+
+  describe '#handle' do
+    it 'raises NotImplementedError when not overridden' do
+      handler = described_class.new(event)
+      expect { handler.handle }.to raise_error(NotImplementedError, 'Each handler must implement the handle method')
+    end
+  end
+end

--- a/spec/services/stripe_event_handlers/dispatcher_spec.rb
+++ b/spec/services/stripe_event_handlers/dispatcher_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe StripeEventHandlers::Dispatcher do
+  describe '.call' do
+    let(:event) { double('event', type: event_type) }
+
+    context 'when event type is customer.subscription.created' do
+      let(:event_type) { 'customer.subscription.created' }
+
+      it 'calls SubscriptionCreated handler' do
+        handler_instance = instance_double(StripeEventHandlers::SubscriptionCreated)
+        expect(StripeEventHandlers::SubscriptionCreated).to receive(:new).with(event).and_return(handler_instance)
+        expect(handler_instance).to receive(:handle)
+        described_class.call(event)
+      end
+    end
+
+    context 'when event type is invoice.payment_succeeded' do
+      let(:event_type) { 'invoice.payment_succeeded' }
+
+      it 'calls PaymentSucceeded handler' do
+        handler_instance = instance_double(StripeEventHandlers::PaymentSucceeded)
+        expect(StripeEventHandlers::PaymentSucceeded).to receive(:new).with(event).and_return(handler_instance)
+        expect(handler_instance).to receive(:handle)
+        described_class.call(event)
+      end
+    end
+
+    context 'when event type is customer.subscription.deleted' do
+      let(:event_type) { 'customer.subscription.deleted' }
+
+      it 'calls SubscriptionDeleted handler' do
+        handler_instance = instance_double(StripeEventHandlers::SubscriptionDeleted)
+        expect(StripeEventHandlers::SubscriptionDeleted).to receive(:new).with(event).and_return(handler_instance)
+        expect(handler_instance).to receive(:handle)
+        described_class.call(event)
+      end
+    end
+
+    context 'when event type is unknown' do
+      let(:event_type) { 'unknown.event.type' }
+
+      it 'raises an error' do
+        expect(described_class.call(event)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/stripe_event_handlers/payment_succeeded_spec.rb
+++ b/spec/services/stripe_event_handlers/payment_succeeded_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe StripeEventHandlers::PaymentSucceeded do
+  describe '.handle' do
+    let(:stripe_subscription_id) { "sub_#{SecureRandom.hex(8)}" }
+    let!(:subscription) { create(:subscription, stripe_subscription_id: stripe_subscription_id) }
+    let(:event) do
+      Stripe::Event.construct_from(
+        id: 'evt_123',
+        type: 'invoice.payment_succeeded',
+        data: { object: { subscription: stripe_subscription_id } }
+      )
+    end
+
+    it 'updates subscription status to paid' do
+      described_class.new(event).handle
+      expect(subscription.reload.status).to eq('paid')
+    end
+  end
+end

--- a/spec/services/stripe_event_handlers/subscription_created_spec.rb
+++ b/spec/services/stripe_event_handlers/subscription_created_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe StripeEventHandlers::SubscriptionCreated do
+  describe '.handle' do
+    let(:stripe_subscription_id) { "sub_#{SecureRandom.hex(8)}" }
+    let(:stripe_customer_id) { "cus_#{SecureRandom.hex(8)}" }
+    let(:event) do
+      Stripe::Event.construct_from(
+        id: 'evt_123',
+        type: 'customer.subscription.created',
+        data: { object: { id: stripe_subscription_id, customer: stripe_customer_id } }
+      )
+    end
+
+    it 'creates a new subscription with unpaid status' do
+      expect do
+        described_class.new(event).handle
+      end.to change(Subscription, :count).by(1)
+      subscription = Subscription.last
+      expect(subscription.stripe_subscription_id).to eq(stripe_subscription_id)
+      expect(subscription.stripe_customer_id).to eq(stripe_customer_id)
+      expect(subscription.status).to eq('unpaid')
+    end
+  end
+end

--- a/spec/services/stripe_event_handlers/subscription_deleted_spec.rb
+++ b/spec/services/stripe_event_handlers/subscription_deleted_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe StripeEventHandlers::SubscriptionDeleted do
+  describe '.handle' do
+    let(:stripe_subscription_id) { "sub_#{SecureRandom.hex(8)}" }
+    let!(:subscription) { create(:subscription, stripe_subscription_id: stripe_subscription_id) }
+    let(:event) do
+      Stripe::Event.construct_from(
+        id: 'evt_123',
+        type: 'customer.subscription.deleted',
+        data: { object: { id: stripe_subscription_id } }
+      )
+    end
+
+    context 'when subscription status is paid' do
+      before { subscription.pay! }
+
+      it 'updates subscription status to canceled' do
+        described_class.new(event).handle
+        expect(subscription.reload.status).to eq('canceled')
+      end
+    end
+
+    context 'when subscription status is unpaid' do
+      it 'does not update subscription status' do
+        described_class.new(event).handle
+        expect(subscription.reload.status).to eq('unpaid')
+      end
+    end
+  end
+end

--- a/spec/services/subscription_service/create_spec.rb
+++ b/spec/services/subscription_service/create_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SubscriptionService::Create do
+  let(:stripe_subscription_id) { "sub_#{SecureRandom.hex(8)}" }
+  let(:stripe_customer_id) { "cus_#{SecureRandom.hex(8)}" }
+  let(:service) { described_class.new(stripe_subscription_id, stripe_customer_id) }
+
+  it 'creates a subscription with unpaid status' do
+    subscription = service.call
+    expect(subscription).to be_persisted
+    expect(subscription.stripe_subscription_id).to eq(stripe_subscription_id)
+    expect(subscription.stripe_customer_id).to eq(stripe_customer_id)
+    expect(subscription.status).to eq('unpaid')
+  end
+end

--- a/spec/services/subscription_service/update_spec.rb
+++ b/spec/services/subscription_service/update_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SubscriptionService::Update do
+  let(:stripe_subscription_id) { "sub_#{SecureRandom.hex(8)}" }
+  let!(:subscription) { create(:subscription, stripe_subscription_id: stripe_subscription_id) }
+
+  context 'invoice.payment_succeeded' do
+    let(:service) { described_class.new(stripe_subscription_id, 'invoice.payment_succeeded') }
+
+    it 'transitions from unpaid to paid' do
+      service.call
+      expect(subscription.reload.status).to eq('paid')
+    end
+  end
+
+  context 'customer.subscription.deleted' do
+    before { subscription.pay! }
+    let(:service) { described_class.new(stripe_subscription_id, 'customer.subscription.deleted') }
+
+    it 'transitions from paid to canceled' do
+      service.call
+      expect(subscription.reload.status).to eq('canceled')
+    end
+  end
+
+  context 'when subscription unpaid' do
+    let(:service) { described_class.new(stripe_subscription_id, 'customer.subscription.deleted') }
+
+    it 'does not transition from unpaid to canceled' do
+      service.call
+      expect(subscription.reload.status).to eq('unpaid')
+    end
+  end
+end


### PR DESCRIPTION
creating a subscription on stripe.com (via subscription UI) creates a simple
subscription record in your database
the initial state of the subscription record should be 'unpaid'
paying the first invoice of the subscription changes the state of your local
subscription record from 'unpaid' to 'paid'
canceling a subscription changes the state of your subscription record to “canceled”
only subscriptions in the state “paid” can be canceled
